### PR TITLE
add base configuration for module

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -2,13 +2,9 @@
 return array(
     'EddieJaoude\Zf2Logger' => array(
 
-        // will add the $logger object before the current PHP error handler
-        'registerErrorHandler'     => true, // errors logged to your writers
-        'registerExceptionHandler' => true, // exceptions logged to your writers
-
         // do not log binary responses
         // mime types reference http://www.sitepoint.com/web-foundations/mime-types-complete-list/
-        'doNotLog'                 => array(
+        'doNotLog' => array(
             'mediaTypes' => array(
                 'application/octet-stream',
                 'image/png',
@@ -16,5 +12,5 @@ return array(
                 'application/pdf'
             ),
         ),
-    )
+    ),
 );


### PR DESCRIPTION
You load local configuration in Module.php so the configuration is needed. I add a default configuration for you to permit the load.

This cannot be seen in unit testing because you add your configuration using mockery.
